### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cloud IoT Core Emulator
 
 This is an implementation of IoT Core emulator based on mosca and express libraries.
-Run the enulator either by using the docker image or directly from nodejs.
+Run the emulator either by using the docker image or directly from nodejs.
 NOTICE: this is still work in progress


### PR DESCRIPTION
The word 'emulator' is misspelled. Corrected it.